### PR TITLE
Clarify compilation failure error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,20 @@ module.exports = function(opts) {
     if (file.isStream()) {
       return cb(new util.PluginError('gulp-haml', 'Streaming not supported'));
     }
-
-    var html = compilers[options.compiler]
-    .render(file.contents.toString('utf8'), options.compilerOpts);
+  
+    try {
+      // Render using the selected compiler
+      var html = compilers[options.compiler]
+      .render(file.contents.toString('utf8'), options.compilerOpts);
+    } catch (e) {
+      return cb(new util.PluginError({
+          plugin: 'gulp-haml', 
+          message: 'HAML conversion failed\n' + file.path +'\n'+ e
+        })
+      )
+    } 
+    
+    
     file.path = rext(file.path, options.ext);
     file.contents = new Buffer(html);
 


### PR DESCRIPTION
This PR improves error handling when HAML conversion fails.

Previous behavior:
```
HamlError: (Haml):2 invalid indentation; got 2, when previous was 0
// Which file broke?
```


The new behavior raises a `util.PluginError` with the failing file path:
```shell
Error in plugin 'gulp-haml'
HAML conversion failed
/path/to/index.haml
HamlError: (Haml):2 invalid indentation; got 2, when previous was 0
```